### PR TITLE
fix #20 crash in isRemovable

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/Storage.java
+++ b/app/src/main/java/com/einmalfel/podlisten/Storage.java
@@ -255,10 +255,15 @@ public class Storage {
   }
 
   public boolean isRemovable() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return Environment.isExternalStorageRemovable(appFilesDir);
-    } else {
-      return isPrimaryStorage() ? Environment.isExternalStorageRemovable() : true;
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        return Environment.isExternalStorageRemovable(appFilesDir);
+      } else {
+        return isPrimaryStorage() ? Environment.isExternalStorageRemovable() : true;
+      }
+    } catch (IllegalArgumentException exc) {
+        Log.e(TAG, "Failed to check isRemovable of " + appFilesDir + ":" + Log.getStackTraceString(exc));
+        return false;
     }
   }
 


### PR DESCRIPTION
The bug is not present in 1.3.6, so maybe you'd want to revert `Storage.java` to a earlier verison. Seems that `/data/data...` returned by `getWritableStorages` is causing problems.